### PR TITLE
Fix save content functionality

### DIFF
--- a/index.html
+++ b/index.html
@@ -533,6 +533,41 @@
             border-radius: 4px;
         }
         
+        .tmdb-status {
+            margin-top: 10px;
+            padding: 10px;
+            border-radius: 6px;
+            font-size: 0.9rem;
+        }
+        
+        .tmdb-status.success {
+            background-color: #e8f5e9;
+            color: #2e7d32;
+            border: 1px solid #81c784;
+        }
+        
+        .tmdb-status.loading {
+            background-color: #e3f2fd;
+            color: #1565c0;
+            border: 1px solid #64b5f6;
+        }
+        
+        .actor-preview {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 5px;
+            margin-top: 5px;
+        }
+        
+        .actor-tag {
+            background-color: #f1f8ff;
+            color: #2980b9;
+            padding: 2px 8px;
+            border-radius: 12px;
+            font-size: 0.8rem;
+            border: 1px solid #e3f2fd;
+        }
+
         /* Responsive */
         @media (max-width: 768px) {
             .load-section {
@@ -630,6 +665,7 @@
                                 <i class="fas fa-cloud-download-alt"></i> Fetch Movie
                             </button>
                         </div>
+                        <div id="movieTmdbStatus" class="tmdb-status" style="display: none;"></div>
                     </div>
                     
                     <div class="form-row">
@@ -687,6 +723,7 @@
                                 <i class="fas fa-cloud-download-alt"></i> Fetch Series
                             </button>
                         </div>
+                        <div id="seriesTmdbStatus" class="tmdb-status" style="display: none;"></div>
                     </div>
                     
                     <div class="form-row">
@@ -803,6 +840,7 @@
             // Movie elements
             const movieTmdbIdInput = document.getElementById('movieTmdbId');
             const fetchMovieTMDbButton = document.getElementById('fetchMovieTMDbButton');
+            const movieTmdbStatus = document.getElementById('movieTmdbStatus');
             const movieTitleInput = document.getElementById('movieTitle');
             const movieYearInput = document.getElementById('movieYear');
             const movieDescriptionInput = document.getElementById('movieDescription');
@@ -817,6 +855,7 @@
             // Series elements
             const seriesTmdbIdInput = document.getElementById('seriesTmdbId');
             const fetchSeriesTMDbButton = document.getElementById('fetchSeriesTMDbButton');
+            const seriesTmdbStatus = document.getElementById('seriesTmdbStatus');
             const seriesTitleInput = document.getElementById('seriesTitle');
             const seriesYearInput = document.getElementById('seriesYear');
             const seriesDescriptionInput = document.getElementById('seriesDescription');
@@ -1227,22 +1266,63 @@
                     throw new Error('Movie title is required');
                 }
                 
+                // Get comprehensive data from TMDB fetch
+                let comprehensiveData = {};
+                try {
+                    const storedData = movieTmdbIdInput.dataset.comprehensiveData;
+                    if (storedData) {
+                        comprehensiveData = JSON.parse(storedData);
+                    }
+                } catch (e) {
+                    console.warn('Could not parse comprehensive data:', e);
+                }
+                
+                // Enhanced sources format matching reference API
+                const enhancedSources = currentMovieSources.map((source, index) => ({
+                    id: source.id || (index + 1),
+                    type: source.type || 'video',
+                    title: source.title || `Source ${index + 1}`,
+                    quality: source.quality || 'HD',
+                    size: 'N/A',
+                    kind: 'both',
+                    premium: 'false',
+                    external: source.external || false,
+                    url: source.url
+                }));
+                
                 const entryData = {
                     type: 'movie',
                     title: title,
-                    year: movieYearInput.value.trim(),
+                    label: comprehensiveData.genres?.[0]?.title || 'Movie',
+                    sublabel: 'Feature Film',
+                    imdb: comprehensiveData.imdb_id || '',
+                    downloadas: `${title.toLowerCase().replace(/\s+/g, '-')}.mp4`,
+                    comment: true,
+                    playas: 'video',
                     description: movieDescriptionInput.value.trim(),
+                    classification: 'PG-13', // Default, could be enhanced from TMDB
+                    year: movieYearInput.value.trim(),
+                    duration: comprehensiveData.runtime ? `${comprehensiveData.runtime}:00` : '120:00',
+                    rating: comprehensiveData.vote_average || 7.0,
                     image: movieImageInput.value.trim(),
                     cover: movieCoverInput.value.trim(),
-                    trailer: movieTrailerInput.value.trim() ? { url: movieTrailerInput.value.trim() } : null,
-                    sources: currentMovieSources,
-                    genres: [],
-                    actors: [],
-                    subtitles: [],
-                    comments: []
+                    genres: comprehensiveData.genres || [],
+                    sources: enhancedSources,
+                    trailer: comprehensiveData.trailer || (movieTrailerInput.value.trim() ? {
+                        id: generateNewId(),
+                        type: 'video',
+                        title: `${title} Trailer`,
+                        url: movieTrailerInput.value.trim()
+                    } : null),
+                    actors: comprehensiveData.actors || [],
+                    subtitles: [], // Could be enhanced later
+                    comments: [], // Empty initially
+                    views: 0,
+                    downloads: 0,
+                    shares: 0
                 };
                 
-                console.log('Movie data to save:', entryData);
+                console.log('Enhanced movie data to save:', entryData);
                 
                 if (id) {
                     // Update existing entry
@@ -1271,51 +1351,95 @@
                     throw new Error('Series title is required');
                 }
                 
-                // Collect season/episode data from the form
-                const seasons = [];
-                const seasonElements = document.querySelectorAll('.season-card');
+                // Get comprehensive data from TMDB fetch
+                let comprehensiveData = {};
+                try {
+                    const storedData = seriesTmdbIdInput.dataset.comprehensiveData;
+                    if (storedData) {
+                        comprehensiveData = JSON.parse(storedData);
+                    }
+                } catch (e) {
+                    console.warn('Could not parse comprehensive series data:', e);
+                }
                 
-                for (const seasonElement of seasonElements) {
-                    const seasonNumber = parseInt(seasonElement.dataset.season);
-                    const episodes = [];
-                    const episodeElements = seasonElement.querySelectorAll('.episode-item');
+                // Use the comprehensive seasons data if available, otherwise collect from form
+                let seasons = [];
+                if (comprehensiveData.seasonsData && comprehensiveData.seasonsData.length > 0) {
+                    seasons = comprehensiveData.seasonsData;
+                    console.log('Using comprehensive seasons data with episodes');
+                } else {
+                    // Fallback to form data collection
+                    const seasonElements = document.querySelectorAll('.season-card');
                     
-                    for (const episodeElement of episodeElements) {
-                        const episodeNumber = parseInt(episodeElement.dataset.episode);
-                        const sourceUrl = episodeElement.querySelector('.episode-sources input').value.trim();
+                    for (const seasonElement of seasonElements) {
+                        const seasonNumber = parseInt(seasonElement.dataset.season);
+                        const episodes = [];
+                        const episodeElements = seasonElement.querySelectorAll('.episode-item');
                         
-                        if (sourceUrl) {
-                            const titleElement = episodeElement.querySelector('.episode-title');
-                            const episodeTitle = titleElement ? titleElement.textContent.replace(/^Episode \d+: /, '') : `Episode ${episodeNumber}`;
+                        for (const episodeElement of episodeElements) {
+                            const episodeNumber = parseInt(episodeElement.dataset.episode);
+                            const sourceUrl = episodeElement.querySelector('.episode-sources input').value.trim();
                             
-                            episodes.push({
-                                episode: episodeNumber,
-                                title: episodeTitle,
-                                sources: [{ url: sourceUrl, type: 'video' }]
+                            if (sourceUrl) {
+                                const titleElement = episodeElement.querySelector('.episode-title');
+                                const episodeTitle = titleElement ? titleElement.textContent.replace(/^Episode \d+: /, '') : `Episode ${episodeNumber}`;
+                                
+                                episodes.push({
+                                    episode: episodeNumber,
+                                    title: episodeTitle,
+                                    sources: [{ 
+                                        id: `${episodeNumber}_1`,
+                                        type: 'video',
+                                        title: 'Source 1',
+                                        quality: 'HD',
+                                        url: sourceUrl 
+                                    }]
+                                });
+                            }
+                        }
+                        
+                        if (episodes.length > 0) {
+                            seasons.push({
+                                season: seasonNumber,
+                                name: `Season ${seasonNumber}`,
+                                episodes: episodes
                             });
                         }
-                    }
-                    
-                    if (episodes.length > 0) {
-                        seasons.push({
-                            season: seasonNumber,
-                            episodes: episodes
-                        });
                     }
                 }
                 
                 const entryData = {
                     type: 'series',
                     title: title,
-                    year: seriesYearInput.value.trim(),
+                    label: comprehensiveData.genres?.[0]?.title || 'Series',
+                    sublabel: 'TV Series',
+                    imdb: comprehensiveData.imdb_id || '',
+                    downloadas: `${title.toLowerCase().replace(/\s+/g, '-')}-series`,
+                    comment: true,
+                    playas: 'video',
                     description: seriesDescriptionInput.value.trim(),
+                    classification: 'TV-14', // Default rating for series
+                    year: seriesYearInput.value.trim(),
+                    rating: comprehensiveData.vote_average || 7.0,
                     image: seriesImageInput.value.trim(),
                     cover: seriesCoverInput.value.trim(),
-                    trailer: seriesTrailerInput.value.trim() ? { url: seriesTrailerInput.value.trim() } : null,
+                    genres: comprehensiveData.genres || [],
+                    trailer: comprehensiveData.trailer || (seriesTrailerInput.value.trim() ? {
+                        id: generateNewId(),
+                        type: 'video',
+                        title: `${title} Trailer`,
+                        url: seriesTrailerInput.value.trim()
+                    } : null),
+                    actors: comprehensiveData.actors || [],
+                    subtitles: [],
+                    comments: [],
+                    views: 0,
+                    downloads: 0,
+                    shares: 0,
                     seasons: seasons
                 };
                 
-                console.log('Series data to save:', entryData);
+                console.log('Enhanced series data to save:', entryData);
                 
                 if (id) {
                     // Update existing entry
@@ -1349,26 +1473,59 @@
                     throw new Error('Stream URL is required');
                 }
                 
+                // Enhanced sources format matching reference API
                 const sources = [];
-                sources.push({ url: streamUrl, type: 'live' });
+                let sourceId = 1;
                 
+                // Main stream source
+                sources.push({
+                    id: sourceId++,
+                    type: 'live',
+                    title: 'HD',
+                    quality: 'HD',
+                    size: 'Live',
+                    kind: 'play',
+                    premium: 'false',
+                    external: false,
+                    url: streamUrl
+                });
+                
+                // Backup stream source if provided
                 const backupUrl = channelBackupUrlInput.value.trim();
                 if (backupUrl) {
-                    sources.push({ url: backupUrl, type: 'live' });
+                    sources.push({
+                        id: sourceId++,
+                        type: 'live',
+                        title: 'Backup',
+                        quality: 'HD',
+                        size: 'Live',
+                        kind: 'play',
+                        premium: 'false',
+                        external: false,
+                        url: backupUrl
+                    });
                 }
                 
                 const entryData = {
                     title: title,
-                    image: channelImageInput.value.trim(),
-                    rating: parseFloat(channelRatingInput.value) || 0,
-                    category: channelCategoryInput.value.trim() || '',
+                    label: channelCategoryInput.value.trim() || 'Entertainment',
+                    sublabel: 'Live TV',
                     description: channelDescriptionInput.value.trim(),
+                    website: '', // Could be enhanced later
+                    classification: channelCategoryInput.value.trim() || 'General',
+                    views: 0,
+                    shares: 0,
+                    rating: parseFloat(channelRatingInput.value) || 7.0,
+                    comment: true,
+                    image: channelImageInput.value.trim(),
+                    playas: 'live',
                     sources: sources,
-                    countries: [],
+                    categories: channelCategoryInput.value.trim() ? [channelCategoryInput.value.trim()] : [],
+                    countries: [], // Could be enhanced later
                     comments: []
                 };
                 
-                console.log('Channel data to save:', entryData);
+                console.log('Enhanced channel data to save:', entryData);
                 
                 if (id) {
                     // Update existing entry
@@ -1542,6 +1699,23 @@
                 }
             }
             
+            async function fetchSeasonEpisodes(tmdbId, seasonNumber) {
+                try {
+                    const url = `https://api.themoviedb.org/3/tv/${tmdbId}/season/${seasonNumber}?api_key=${tmdbApiKey}`;
+                    const res = await fetch(url);
+                    
+                    if (!res.ok) {
+                        throw new Error(`Failed to fetch season ${seasonNumber} data`);
+                    }
+                    
+                    const seasonData = await res.json();
+                    return seasonData.episodes || [];
+                } catch (error) {
+                    console.error(`Error fetching season ${seasonNumber} episodes:`, error);
+                    return [];
+                }
+            }
+            
             async function fetchComprehensiveSeriesData(tmdbId) {
                 try {
                     console.log('Fetching comprehensive series data for TMDB ID:', tmdbId);
@@ -1571,13 +1745,47 @@
                         title: genre.name
                     })) || [];
                     
-                    // Prepare seasons data for series
-                    const seasonsData = seriesData.seasons?.filter(s => s.season_number > 0).map(season => ({
-                        season: season.season_number,
-                        name: season.name,
-                        episode_count: season.episode_count,
-                        episodes: [] // Will be populated with manual episode data entry
-                    })) || [];
+                    // Fetch detailed season and episode data
+                    const seasonsWithEpisodes = [];
+                    const availableSeasons = seriesData.seasons?.filter(s => s.season_number > 0) || [];
+                    
+                    for (const season of availableSeasons) {
+                        console.log(`Fetching episodes for season ${season.season_number}`);
+                        const episodes = await fetchSeasonEpisodes(tmdbId, season.season_number);
+                        
+                        // Generate episodes with vidsrc.net links
+                        const episodesWithSources = episodes.map(episode => ({
+                            episode: episode.episode_number,
+                            title: episode.name || `Episode ${episode.episode_number}`,
+                            overview: episode.overview || '',
+                            air_date: episode.air_date || '',
+                            runtime: episode.runtime || null,
+                            vote_average: episode.vote_average || 0,
+                            still_path: episode.still_path ? 
+                                `https://image.tmdb.org/t/p/w300${episode.still_path}` : null,
+                            sources: [
+                                {
+                                    id: `${tmdbId}_s${season.season_number}_e${episode.episode_number}`,
+                                    type: 'video',
+                                    title: 'vidsrc.net',
+                                    quality: 'HD',
+                                    url: `https://vidsrc.net/embed/tv/${tmdbId}/${season.season_number}/${episode.episode_number}`,
+                                    external: false
+                                }
+                            ]
+                        }));
+                        
+                        seasonsWithEpisodes.push({
+                            season: season.season_number,
+                            name: season.name || `Season ${season.season_number}`,
+                            overview: season.overview || '',
+                            episode_count: season.episode_count,
+                            air_date: season.air_date || '',
+                            poster_path: season.poster_path ? 
+                                `https://image.tmdb.org/t/p/w300${season.poster_path}` : null,
+                            episodes: episodesWithSources
+                        });
+                    }
                     
                     return {
                         ...seriesData,
@@ -1589,7 +1797,7 @@
                             title: trailer.name || 'Trailer',
                             url: `https://www.youtube.com/watch?v=${trailer.key}`
                         } : null,
-                        seasonsData: seasonsData
+                        seasonsData: seasonsWithEpisodes
                     };
                 } catch (error) {
                     console.error('Error fetching comprehensive series data:', error);
@@ -1619,10 +1827,20 @@
                     return;
                 }
                 
+                // Show loading state
+                const originalText = fetchMovieTMDbButton.innerHTML;
+                fetchMovieTMDbButton.disabled = true;
+                fetchMovieTMDbButton.innerHTML = '<i class="fas fa-spinner fa-spin"></i> Fetching...';
+                
+                // Show status
+                movieTmdbStatus.style.display = 'block';
+                movieTmdbStatus.className = 'tmdb-status loading';
+                movieTmdbStatus.innerHTML = '<i class="fas fa-spinner fa-spin"></i> Fetching movie data from TMDb...';
+                
                 try {
-                    const movieData = await fetchTMDbData('movie', tmdbId);
+                    const movieData = await fetchComprehensiveMovieData(tmdbId);
                     
-                    // Populate form
+                    // Populate form with comprehensive data
                     movieTitleInput.value = movieData.title;
                     movieYearInput.value = movieData.release_date ? movieData.release_date.split('-')[0] : '';
                     movieDescriptionInput.value = movieData.overview || '';
@@ -1631,21 +1849,57 @@
                     movieCoverInput.value = movieData.backdrop_path ? 
                         `https://image.tmdb.org/t/p/original${movieData.backdrop_path}` : '';
                     
-                    // Fetch trailer
-                    const videosUrl = `https://api.themoviedb.org/3/movie/${tmdbId}/videos?api_key=${tmdbApiKey}`;
-                    const videosRes = await fetch(videosUrl);
-                    const videosData = videosRes.ok ? await videosRes.json() : { results: [] };
-                    const trailer = videosData.results.find(v => v.site === 'YouTube' && v.type === 'Trailer');
-                    movieTrailerInput.value = trailer ? `https://www.youtube.com/watch?v=${trailer.key}` : '';
+                    // Set trailer URL
+                    movieTrailerInput.value = movieData.extractedTrailer ? movieData.extractedTrailer.url : '';
                     
-                    // Auto-add vidsrc source
+                    // Auto-add vidsrc source with multiple quality options
                     const vidsrcUrl = `https://vidsrc.net/embed/movie/${tmdbId}`;
-                    currentMovieSources = [{ title: 'vidsrc.net', url: vidsrcUrl, type: 'video' }];
+                    currentMovieSources = [
+                        { 
+                            id: `${tmdbId}_hd`,
+                            title: 'vidsrc.net HD', 
+                            url: vidsrcUrl, 
+                            type: 'video',
+                            quality: 'HD',
+                            external: false
+                        }
+                    ];
                     renderMovieSources();
                     
-                    showNotification('Movie data fetched successfully!', true);
+                    // Store comprehensive data for saving
+                    movieTmdbIdInput.dataset.comprehensiveData = JSON.stringify({
+                        actors: movieData.extractedActors,
+                        genres: movieData.extractedGenres,
+                        trailer: movieData.extractedTrailer,
+                        imdb_id: movieData.imdb_id,
+                        runtime: movieData.runtime,
+                        vote_average: movieData.vote_average,
+                        popularity: movieData.popularity
+                    });
+                    
+                    // Show success status
+                    movieTmdbStatus.className = 'tmdb-status success';
+                    movieTmdbStatus.innerHTML = `
+                        <i class="fas fa-check-circle"></i> Successfully fetched: ${movieData.title} (${movieData.release_date?.split('-')[0] || 'N/A'})
+                        <div class="actor-preview">
+                            ${movieData.extractedActors.slice(0, 4).map(actor => 
+                                `<span class="actor-tag">${actor.name}</span>`
+                            ).join('')}
+                            ${movieData.extractedActors.length > 4 ? `<span class="actor-tag">+${movieData.extractedActors.length - 4} more</span>` : ''}
+                        </div>
+                    `;
+                    
+                    showNotification(`Movie data fetched successfully! Found ${movieData.extractedActors.length} actors.`, true);
                 } catch (error) {
+                    movieTmdbStatus.className = 'tmdb-status';
+                    movieTmdbStatus.style.backgroundColor = '#ffebee';
+                    movieTmdbStatus.style.color = '#c62828';
+                    movieTmdbStatus.style.border = '1px solid #ef9a9a';
+                    movieTmdbStatus.innerHTML = `<i class="fas fa-exclamation-triangle"></i> Error: ${error.message}`;
                     showNotification(`Error: ${error.message}`, false);
+                } finally {
+                    fetchMovieTMDbButton.disabled = false;
+                    fetchMovieTMDbButton.innerHTML = originalText;
                 }
             });
             
@@ -1656,10 +1910,15 @@
                     return;
                 }
                 
+                // Show loading state
+                const originalText = fetchSeriesTMDbButton.innerHTML;
+                fetchSeriesTMDbButton.disabled = true;
+                fetchSeriesTMDbButton.innerHTML = '<i class="fas fa-spinner fa-spin"></i> Fetching Episodes...';
+                
                 try {
-                    const seriesData = await fetchSeriesDetails(tmdbId);
+                    const seriesData = await fetchComprehensiveSeriesData(tmdbId);
                     
-                    // Populate form
+                    // Populate form with comprehensive data
                     seriesTitleInput.value = seriesData.name;
                     seriesYearInput.value = seriesData.first_air_date ? seriesData.first_air_date.split('-')[0] : '';
                     seriesDescriptionInput.value = seriesData.overview || '';
@@ -1667,23 +1926,35 @@
                         `https://image.tmdb.org/t/p/w500${seriesData.poster_path}` : '';
                     seriesCoverInput.value = seriesData.backdrop_path ? 
                         `https://image.tmdb.org/t/p/original${seriesData.backdrop_path}` : '';
-                    seriesTrailerInput.value = seriesData.trailer || '';
+                    seriesTrailerInput.value = seriesData.extractedTrailer ? seriesData.extractedTrailer.url : '';
                     
-                    // Prepare seasons data
+                    // Use the comprehensive seasons data with episodes and vidsrc links
                     currentSeriesData = {
                         ...seriesData,
-                        seasons: seriesData.seasons.filter(s => s.season_number > 0).map(season => ({
-                            season: season.season_number,
-                            episodes: []
-                        }))
+                        seasons: seriesData.seasonsData
                     };
                     
-                    // Render seasons
-                    renderSeasons(currentSeriesData.seasons);
+                    // Render seasons with episodes
+                    await renderSeasons(currentSeriesData.seasons);
                     
-                    showNotification('Series data fetched successfully!', true);
+                    // Store comprehensive data for saving
+                    seriesTmdbIdInput.dataset.comprehensiveData = JSON.stringify({
+                        actors: seriesData.extractedActors,
+                        genres: seriesData.extractedGenres,
+                        trailer: seriesData.extractedTrailer,
+                        imdb_id: seriesData.imdb_id,
+                        vote_average: seriesData.vote_average,
+                        popularity: seriesData.popularity,
+                        seasonsData: seriesData.seasonsData
+                    });
+                    
+                    const totalEpisodes = seriesData.seasonsData.reduce((total, season) => total + season.episodes.length, 0);
+                    showNotification(`Series data fetched successfully! Found ${seriesData.seasonsData.length} seasons with ${totalEpisodes} episodes and ${seriesData.extractedActors.length} actors.`, true);
                 } catch (error) {
                     showNotification(`Error: ${error.message}`, false);
+                } finally {
+                    fetchSeriesTMDbButton.disabled = false;
+                    fetchSeriesTMDbButton.innerHTML = originalText;
                 }
             });
             

--- a/index.html
+++ b/index.html
@@ -1486,7 +1486,7 @@
                     throw new Error('Invalid content type');
                 }
                 
-                const url = `${baseUrl}/${endpoint}?api_key=${tmdbApiKey}`;
+                const url = `${baseUrl}/${endpoint}?api_key=${tmdbApiKey}&append_to_response=credits,videos,images`;
                 const res = await fetch(url);
                 
                 if (!res.ok) {
@@ -1494,6 +1494,107 @@
                 }
                 
                 return await res.json();
+            }
+            
+            async function fetchComprehensiveMovieData(tmdbId) {
+                try {
+                    console.log('Fetching comprehensive movie data for TMDB ID:', tmdbId);
+                    
+                    // Fetch main movie data with credits, videos, and images
+                    const movieData = await fetchTMDbData('movie', tmdbId);
+                    
+                    // Extract trailer
+                    const trailer = movieData.videos?.results?.find(v => 
+                        v.site === 'YouTube' && v.type === 'Trailer'
+                    );
+                    
+                    // Extract main actors (first 10)
+                    const actors = movieData.credits?.cast?.slice(0, 10).map((actor, index) => ({
+                        id: actor.id,
+                        name: actor.name,
+                        type: 'actor',
+                        role: actor.character || 'Actor',
+                        image: actor.profile_path ? 
+                            `https://image.tmdb.org/t/p/w185${actor.profile_path}` : null,
+                        order: index + 1
+                    })) || [];
+                    
+                    // Extract genres
+                    const genres = movieData.genres?.map(genre => ({
+                        id: genre.id,
+                        title: genre.name
+                    })) || [];
+                    
+                    return {
+                        ...movieData,
+                        extractedActors: actors,
+                        extractedGenres: genres,
+                        extractedTrailer: trailer ? {
+                            id: trailer.id,
+                            type: 'video',
+                            title: trailer.name || 'Trailer',
+                            url: `https://www.youtube.com/watch?v=${trailer.key}`
+                        } : null
+                    };
+                } catch (error) {
+                    console.error('Error fetching comprehensive movie data:', error);
+                    throw error;
+                }
+            }
+            
+            async function fetchComprehensiveSeriesData(tmdbId) {
+                try {
+                    console.log('Fetching comprehensive series data for TMDB ID:', tmdbId);
+                    
+                    // Fetch main series data with credits, videos, and images
+                    const seriesData = await fetchTMDbData('series', tmdbId);
+                    
+                    // Extract trailer
+                    const trailer = seriesData.videos?.results?.find(v => 
+                        v.site === 'YouTube' && v.type === 'Trailer'
+                    );
+                    
+                    // Extract main actors (first 10)
+                    const actors = seriesData.credits?.cast?.slice(0, 10).map((actor, index) => ({
+                        id: actor.id,
+                        name: actor.name,
+                        type: 'actor',
+                        role: actor.character || 'Actor',
+                        image: actor.profile_path ? 
+                            `https://image.tmdb.org/t/p/w185${actor.profile_path}` : null,
+                        order: index + 1
+                    })) || [];
+                    
+                    // Extract genres
+                    const genres = seriesData.genres?.map(genre => ({
+                        id: genre.id,
+                        title: genre.name
+                    })) || [];
+                    
+                    // Prepare seasons data for series
+                    const seasonsData = seriesData.seasons?.filter(s => s.season_number > 0).map(season => ({
+                        season: season.season_number,
+                        name: season.name,
+                        episode_count: season.episode_count,
+                        episodes: [] // Will be populated with manual episode data entry
+                    })) || [];
+                    
+                    return {
+                        ...seriesData,
+                        extractedActors: actors,
+                        extractedGenres: genres,
+                        extractedTrailer: trailer ? {
+                            id: trailer.id,
+                            type: 'video',
+                            title: trailer.name || 'Trailer',
+                            url: `https://www.youtube.com/watch?v=${trailer.key}`
+                        } : null,
+                        seasonsData: seasonsData
+                    };
+                } catch (error) {
+                    console.error('Error fetching comprehensive series data:', error);
+                    throw error;
+                }
             }
             
             async function fetchSeriesDetails(tmdbId) {

--- a/index.html
+++ b/index.html
@@ -767,7 +767,7 @@
                 </div>
                 
                 <div class="form-group" style="margin-top: 20px; text-align: center;">
-                    <button type="submit" style="padding: 12px 30px; font-size: 1.1rem;">
+                    <button type="submit" id="saveContentButton" style="padding: 12px 30px; font-size: 1.1rem;">
                         <i class="fas fa-save"></i> Save Content
                     </button>
                 </div>
@@ -1163,31 +1163,78 @@
             
             entryForm.addEventListener('submit', (event) => {
                 event.preventDefault();
-                const id = entryIdInput.value;
-                const activeTab = document.querySelector('.tab-btn.active').dataset.type;
+                console.log('Form submission started');
                 
-                if (activeTab === 'channel') {
-                    saveChannel(id);
-                } else if (activeTab === 'series') {
-                    saveSeries(id);
-                } else {
-                    saveMovie(id);
-                }
+                const saveButton = document.getElementById('saveContentButton');
+                const originalButtonText = saveButton.innerHTML;
                 
-                renderEntries();
-                closeModal();
-                showNotification('Content saved successfully!', true);
+                // Show loading state
+                saveButton.disabled = true;
+                saveButton.innerHTML = '<i class="fas fa-spinner fa-spin"></i> Saving...';
+                
+                // Small delay to show the loading state
+                setTimeout(() => {
+                    try {
+                        // Ensure jsonData is initialized
+                        if (!jsonData) {
+                            console.log('Initializing jsonData');
+                            jsonData = { movies: [], channels: [] };
+                            editorDiv.style.display = 'block';
+                            saveSectionDiv.style.display = 'block';
+                        }
+                        
+                        const id = entryIdInput.value;
+                        const activeTab = document.querySelector('.tab-btn.active');
+                        
+                        if (!activeTab) {
+                            console.error('No active tab found');
+                            throw new Error('No content type selected');
+                        }
+                        
+                        const contentType = activeTab.dataset.type;
+                        console.log('Saving content type:', contentType, 'with ID:', id);
+                        
+                        if (contentType === 'channel') {
+                            saveChannel(id);
+                        } else if (contentType === 'series') {
+                            saveSeries(id);
+                        } else {
+                            saveMovie(id);
+                        }
+                        
+                        console.log('Content saved successfully');
+                        renderEntries();
+                        closeModal();
+                        showNotification('Content saved successfully!', true);
+                        
+                    } catch (error) {
+                        console.error('Error saving content:', error);
+                        showNotification(`Error saving content: ${error.message}`, false);
+                    } finally {
+                        // Reset button state
+                        saveButton.disabled = false;
+                        saveButton.innerHTML = originalButtonText;
+                    }
+                }, 100);
             });
             
             function saveMovie(id) {
+                console.log('Saving movie with ID:', id);
+                
+                // Validation
+                const title = movieTitleInput.value.trim();
+                if (!title) {
+                    throw new Error('Movie title is required');
+                }
+                
                 const entryData = {
                     type: 'movie',
-                    title: movieTitleInput.value,
-                    year: movieYearInput.value,
-                    description: movieDescriptionInput.value,
-                    image: movieImageInput.value,
-                    cover: movieCoverInput.value,
-                    trailer: movieTrailerInput.value ? { url: movieTrailerInput.value } : null,
+                    title: title,
+                    year: movieYearInput.value.trim(),
+                    description: movieDescriptionInput.value.trim(),
+                    image: movieImageInput.value.trim(),
+                    cover: movieCoverInput.value.trim(),
+                    trailer: movieTrailerInput.value.trim() ? { url: movieTrailerInput.value.trim() } : null,
                     sources: currentMovieSources,
                     genres: [],
                     actors: [],
@@ -1195,18 +1242,35 @@
                     comments: []
                 };
                 
+                console.log('Movie data to save:', entryData);
+                
                 if (id) {
+                    // Update existing entry
                     const index = jsonData.movies.findIndex(m => m.id == id);
                     if (index > -1) {
                         jsonData.movies[index] = { ...jsonData.movies[index], ...entryData };
+                        console.log('Updated existing movie at index:', index);
+                    } else {
+                        console.error('Movie with ID not found:', id);
+                        throw new Error('Movie not found for update');
                     }
                 } else {
+                    // Add new entry
                     const newId = generateNewId();
                     jsonData.movies.push({ id: newId, ...entryData });
+                    console.log('Added new movie with ID:', newId);
                 }
             }
             
             function saveSeries(id) {
+                console.log('Saving series with ID:', id);
+                
+                // Validation
+                const title = seriesTitleInput.value.trim();
+                if (!title) {
+                    throw new Error('Series title is required');
+                }
+                
                 // Collect season/episode data from the form
                 const seasons = [];
                 const seasonElements = document.querySelectorAll('.season-card');
@@ -1242,54 +1306,85 @@
                 
                 const entryData = {
                     type: 'series',
-                    title: seriesTitleInput.value,
-                    year: seriesYearInput.value,
-                    description: seriesDescriptionInput.value,
-                    image: seriesImageInput.value,
-                    cover: seriesCoverInput.value,
-                    trailer: seriesTrailerInput.value ? { url: seriesTrailerInput.value } : null,
+                    title: title,
+                    year: seriesYearInput.value.trim(),
+                    description: seriesDescriptionInput.value.trim(),
+                    image: seriesImageInput.value.trim(),
+                    cover: seriesCoverInput.value.trim(),
+                    trailer: seriesTrailerInput.value.trim() ? { url: seriesTrailerInput.value.trim() } : null,
                     seasons: seasons
                 };
                 
+                console.log('Series data to save:', entryData);
+                
                 if (id) {
+                    // Update existing entry
                     const index = jsonData.movies.findIndex(m => m.id == id);
                     if (index > -1) {
                         jsonData.movies[index] = { ...jsonData.movies[index], ...entryData };
+                        console.log('Updated existing series at index:', index);
+                    } else {
+                        console.error('Series with ID not found:', id);
+                        throw new Error('Series not found for update');
                     }
                 } else {
+                    // Add new entry
                     const newId = generateNewId();
                     jsonData.movies.push({ id: newId, ...entryData });
+                    console.log('Added new series with ID:', newId);
                 }
             }
             
             function saveChannel(id) {
-                const sources = [];
-                if (channelStreamUrlInput.value.trim()) {
-                    sources.push({ url: channelStreamUrlInput.value.trim(), type: 'live' });
+                console.log('Saving channel with ID:', id);
+                
+                // Validation
+                const title = channelTitleInput.value.trim();
+                if (!title) {
+                    throw new Error('Channel title is required');
                 }
-                if (channelBackupUrlInput.value.trim()) {
-                    sources.push({ url: channelBackupUrlInput.value.trim(), type: 'live' });
+                
+                const streamUrl = channelStreamUrlInput.value.trim();
+                if (!streamUrl) {
+                    throw new Error('Stream URL is required');
+                }
+                
+                const sources = [];
+                sources.push({ url: streamUrl, type: 'live' });
+                
+                const backupUrl = channelBackupUrlInput.value.trim();
+                if (backupUrl) {
+                    sources.push({ url: backupUrl, type: 'live' });
                 }
                 
                 const entryData = {
-                    title: channelTitleInput.value,
-                    image: channelImageInput.value,
+                    title: title,
+                    image: channelImageInput.value.trim(),
                     rating: parseFloat(channelRatingInput.value) || 0,
-                    category: channelCategoryInput.value || '',
-                    description: channelDescriptionInput.value,
+                    category: channelCategoryInput.value.trim() || '',
+                    description: channelDescriptionInput.value.trim(),
                     sources: sources,
                     countries: [],
                     comments: []
                 };
                 
+                console.log('Channel data to save:', entryData);
+                
                 if (id) {
+                    // Update existing entry
                     const index = jsonData.channels.findIndex(c => c.id == id);
                     if (index > -1) {
                         jsonData.channels[index] = { ...jsonData.channels[index], ...entryData };
+                        console.log('Updated existing channel at index:', index);
+                    } else {
+                        console.error('Channel with ID not found:', id);
+                        throw new Error('Channel not found for update');
                     }
                 } else {
+                    // Add new entry
                     const newId = generateNewId();
                     jsonData.channels.push({ id: newId, ...entryData });
+                    console.log('Added new channel with ID:', newId);
                 }
             }
             

--- a/index.html
+++ b/index.html
@@ -590,6 +590,14 @@
         <header>
             <h1><i class="fas fa-film"></i> Enhanced Movie API Editor</h1>
             <p class="subtitle">Create and manage your movie, series, and live TV content with TMDb integration</p>
+            <div style="margin-top: 15px;">
+                <button id="clearDataButton" style="background-color: var(--danger); padding: 8px 15px; font-size: 0.9rem;">
+                    <i class="fas fa-trash-alt"></i> Clear All Data
+                </button>
+                <span id="autoSaveStatus" style="margin-left: 15px; color: rgba(255,255,255,0.8); font-size: 0.85rem;">
+                    <i class="fas fa-save"></i> Auto-save enabled
+                </span>
+            </div>
         </header>
 
         <div class="card">
@@ -629,6 +637,13 @@
                 <h2><i class="fas fa-save"></i> 3. Save Data</h2>
                 <div class="save-section">
                     <button id="saveButton"><i class="fas fa-download"></i> Save and Download JSON</button>
+                    <button id="exportButton" style="margin-left: 10px; background-color: var(--primary);">
+                        <i class="fas fa-file-export"></i> Export Current Work
+                    </button>
+                    <input type="file" id="importInput" accept=".json" style="display: none;">
+                    <button id="importButton" style="margin-left: 10px; background-color: var(--warning);">
+                        <i class="fas fa-file-import"></i> Import Backup
+                    </button>
                 </div>
             </div>
         </div>
@@ -827,7 +842,12 @@
             const entryListDiv = document.getElementById('entryList');
             const addNewEntryButton = document.getElementById('addNewEntry');
             const saveButton = document.getElementById('saveButton');
+            const exportButton = document.getElementById('exportButton');
+            const importButton = document.getElementById('importButton');
+            const importInput = document.getElementById('importInput');
             const filterButtons = document.querySelectorAll('.filter-btn');
+            const clearDataButton = document.getElementById('clearDataButton');
+            const autoSaveStatus = document.getElementById('autoSaveStatus');
             
             // Modal elements
             const modal = document.getElementById('entryModal');
@@ -878,6 +898,86 @@
             let currentMovieSources = [];
             let currentFilter = 'all';
             let currentSeriesData = { seasons: [] };
+            
+            // --- Persistence Functions ---
+            function saveToLocalStorage(showIndicator = false) {
+                if (jsonData) {
+                    try {
+                        localStorage.setItem('movieApiData', JSON.stringify(jsonData));
+                        localStorage.setItem('movieApiDataTimestamp', Date.now().toString());
+                        console.log('Data saved to localStorage');
+                        
+                        if (showIndicator && autoSaveStatus) {
+                            const originalText = autoSaveStatus.innerHTML;
+                            autoSaveStatus.innerHTML = '<i class="fas fa-check"></i> Auto-saved just now';
+                            autoSaveStatus.style.color = '#2ecc71';
+                            
+                            setTimeout(() => {
+                                autoSaveStatus.innerHTML = '<i class="fas fa-save"></i> Auto-save enabled';
+                                autoSaveStatus.style.color = 'rgba(255,255,255,0.8)';
+                            }, 2000);
+                        }
+                    } catch (error) {
+                        console.warn('Failed to save to localStorage:', error);
+                        if (autoSaveStatus) {
+                            autoSaveStatus.innerHTML = '<i class="fas fa-exclamation-triangle"></i> Auto-save failed';
+                            autoSaveStatus.style.color = '#e74c3c';
+                        }
+                    }
+                }
+            }
+            
+            function loadFromLocalStorage() {
+                try {
+                    const savedData = localStorage.getItem('movieApiData');
+                    const timestamp = localStorage.getItem('movieApiDataTimestamp');
+                    
+                    if (savedData) {
+                        const parsedData = JSON.parse(savedData);
+                        const savedTime = new Date(parseInt(timestamp || '0'));
+                        
+                        // Auto-load if data exists
+                        jsonData = parsedData;
+                        if (!jsonData.movies) jsonData.movies = [];
+                        if (!jsonData.channels) jsonData.channels = [];
+                        
+                        editorDiv.style.display = 'block';
+                        saveSectionDiv.style.display = 'block';
+                        renderEntries();
+                        
+                        const timeAgo = Math.round((Date.now() - savedTime.getTime()) / (1000 * 60));
+                        showNotification(`Previous work restored! Last saved ${timeAgo} minutes ago.`, true);
+                        console.log('Data loaded from localStorage');
+                        return true;
+                    }
+                } catch (error) {
+                    console.warn('Failed to load from localStorage:', error);
+                    localStorage.removeItem('movieApiData');
+                    localStorage.removeItem('movieApiDataTimestamp');
+                }
+                return false;
+            }
+            
+            function clearLocalStorage() {
+                localStorage.removeItem('movieApiData');
+                localStorage.removeItem('movieApiDataTimestamp');
+                console.log('localStorage cleared');
+            }
+            
+            // Auto-save functionality
+            function setupAutoSave() {
+                // Save data every 30 seconds if there are changes
+                setInterval(() => {
+                    if (jsonData && (jsonData.movies?.length > 0 || jsonData.channels?.length > 0)) {
+                        saveToLocalStorage(true); // Show indicator for auto-save
+                    }
+                }, 30000);
+                
+                // Save before page unload
+                window.addEventListener('beforeunload', () => {
+                    saveToLocalStorage();
+                });
+            }
             
             // --- Utility Functions ---
             function showNotification(message, isSuccess = true) {
@@ -1002,6 +1102,9 @@
                 editorDiv.style.display = 'block';
                 saveSectionDiv.style.display = 'block';
                 renderEntries();
+                
+                // Save to localStorage after loading new data
+                saveToLocalStorage();
             }
             
             // --- Render Entries ---
@@ -1197,6 +1300,9 @@
                 if (index > -1) {
                     showNotification(`${type.charAt(0).toUpperCase() + type.slice(1)} deleted successfully!`, true);
                     renderEntries();
+                    
+                    // Save to localStorage after deletion
+                    saveToLocalStorage();
                 }
             }
             
@@ -1241,10 +1347,13 @@
                             saveMovie(id);
                         }
                         
-                        console.log('Content saved successfully');
-                        renderEntries();
-                        closeModal();
-                        showNotification('Content saved successfully!', true);
+                                            console.log('Content saved successfully');
+                    renderEntries();
+                    closeModal();
+                    
+                    // Save to localStorage after successful save
+                    saveToLocalStorage();
+                    showNotification('Content saved successfully!', true);
                         
                     } catch (error) {
                         console.error('Error saving content:', error);
@@ -1979,6 +2088,88 @@
                 showNotification('File downloaded successfully!', true);
             });
             
+            // --- Export Current Work ---
+            exportButton.addEventListener('click', () => {
+                if (!jsonData) {
+                    showNotification('No data to export', false);
+                    return;
+                }
+                
+                const exportData = {
+                    exported_at: new Date().toISOString(),
+                    version: '1.0',
+                    data: jsonData
+                };
+                
+                const jsonString = JSON.stringify(exportData, null, 2);
+                const blob = new Blob([jsonString], { type: 'application/json' });
+                const url = URL.createObjectURL(blob);
+                const a = document.createElement('a');
+                a.href = url;
+                a.download = `movie_api_backup_${new Date().toISOString().split('T')[0]}.json`;
+                document.body.appendChild(a);
+                a.click();
+                document.body.removeChild(a);
+                URL.revokeObjectURL(url);
+                
+                showNotification('Backup exported successfully!', true);
+            });
+            
+            // --- Import Backup ---
+            importButton.addEventListener('click', () => {
+                importInput.click();
+            });
+            
+            importInput.addEventListener('change', (event) => {
+                const file = event.target.files[0];
+                if (file) {
+                    const reader = new FileReader();
+                    reader.onload = (e) => {
+                        try {
+                            const importedData = JSON.parse(e.target.result);
+                            
+                            // Check if it's a backup file or regular data
+                            const dataToLoad = importedData.data ? importedData.data : importedData;
+                            
+                            // Confirm before loading
+                            const existingItems = (jsonData?.movies?.length || 0) + (jsonData?.channels?.length || 0);
+                            if (existingItems > 0) {
+                                if (!confirm('This will replace your current data. Continue?')) {
+                                    importInput.value = '';
+                                    return;
+                                }
+                            }
+                            
+                            loadData(JSON.stringify(dataToLoad));
+                            showNotification('Backup imported successfully!', true);
+                            
+                        } catch (error) {
+                            showNotification(`Error importing backup: ${error.message}`, false);
+                        }
+                        importInput.value = '';
+                    };
+                    reader.readAsText(file);
+                }
+            });
+            
+            // --- Clear Data Functionality ---
+            clearDataButton.addEventListener('click', () => {
+                if (confirm('Are you sure you want to clear all data? This action cannot be undone.')) {
+                    jsonData = { movies: [], channels: [] };
+                    clearLocalStorage();
+                    editorDiv.style.display = 'none';
+                    saveSectionDiv.style.display = 'none';
+                    entryListDiv.innerHTML = '';
+                    
+                    // Clear form inputs
+                    fileInput.value = '';
+                    jsonTextInput.value = '';
+                    fileInfo.innerHTML = '';
+                    
+                    showNotification('All data cleared successfully!', true);
+                }
+            });
+            
             // --- Event Listeners ---
             closeModalButton.addEventListener('click', closeModal);
             window.addEventListener('click', (event) => {
@@ -1986,6 +2177,17 @@
                     closeModal();
                 }
             });
+            
+            // --- Initialize Application ---
+            // Try to load saved data on page load
+            const dataLoaded = loadFromLocalStorage();
+            if (!dataLoaded) {
+                // Show helpful message if no saved data
+                autoSaveStatus.innerHTML = '<i class="fas fa-info-circle"></i> Load data or add content to enable auto-save';
+            }
+            
+            // Setup auto-save functionality
+            setupAutoSave();
         });
     </script>
 </body>


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fixes "Save Content" button, enhances TMDB data fetching for movies/series, and adds data persistence.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This resolves the non-functional save button and fulfills requests for comprehensive TMDB data (actors, trailers, genres, and auto-generated vidsrc.net links for series episodes) and robust data persistence (auto-save, export/import, clear data) to prevent data loss on refresh.

---
<a href="https://cursor.com/background-agent?bcId=bc-f738ac54-7e8c-4197-be61-18cec50183de">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f738ac54-7e8c-4197-be61-18cec50183de">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>